### PR TITLE
Add contextual information to be used in mocha reporters

### DIFF
--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -801,6 +801,8 @@ Frisby.prototype.toss = function(retry) {
         failedCount: 0
       };
 
+      it.request = self.current.outgoing;
+
       // launch request
       // repeat request for self.current.retry times if request does not respond with self._timeout ms (except for POST requests)
       var tries = 0;
@@ -850,6 +852,7 @@ Frisby.prototype.toss = function(retry) {
       // called from makeRequest if request has finished successfully
       function assert() {
         var i;
+        it.response = self.current.response;
         self.current.expectsFailed = true;
 
         // if you have no expects, they can't fail


### PR DESCRIPTION
I was unsatisfied with Mocha's default output for failures when used with frisby--
When a test fails it spits out a stack trace, which is less than useful when you're debugging an HTTP request.

This change attaches the request and response to the test so that they may be referenced from a custom mocha reporter. I may release the reporter as well, if this is merged. It basically just displays the exact request made (in the form of a curl command) and the raw response that was returned. This helps to quickly fix issues when they occur.