### PR TITLE
Remove unnecessary branding from mocha output

### DIFF
--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -366,7 +366,7 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
 
       // Timeout is now handled by request
       if(err) {
-        body = "[IcedFrisby] Destination URL may be down or URL is invalid, " + err;
+        body = "Destination URL may be down or URL is invalid, " + err;
       }
 
       var diff = (new Date()).getTime() - start;
@@ -735,7 +735,7 @@ Frisby.prototype.toss = function(retry) {
   }
 
   // Assemble all tests and RUN them!
-  describe('[IcedFrisby] ' + self.current.describe, function() {
+  describe(self.current.describe, function() {
     it("\n\t[ " + self.current.itInfo + " ]", function(done) {
       // Ensure "it" scope is accessible to tests
       var it = this;


### PR DESCRIPTION
The `[IcedFrisby]` branding currently attached to every test name is unnecessary and dirties the output.