### PR TITLE
Fixes issue #6 where inspect*() does not work if the test does not pass.

### DIFF
--- a/API.md
+++ b/API.md
@@ -354,14 +354,72 @@ frisby.create('First test')
 ## Inspectors
 Inspectors are useful for viewing details about HTTP requests and responses in the console.
 
-### inspectJSON()
-Dumps parsed JSON body to the console.
+### inspect(cb)
+Provides access to request and response data before expectations are executed. This should not be used for assertions. Use [after()](https://github.com/RobertHerhold/IcedFrisby/blob/master/API.md#after) for more assertions.
+* Types: `cb`: `function(err, req, res, body, headers)`
+  - callback types:
+    * `err`: `Error` object is there was an error making the request. Will be `null` if no error is present.
+	* `req`: request `object` IcedFrisby made to the endpoint
+	* `res`: response `object` received from the endpoint
+	* `body`: body `object`, a part of the response
+	* `headers`: headers `object`, a part of the response
+* Defaults: `none`, performs no action if the callback is a false value
+
+```javascript
+frisby.create('Inspecting some data')
+  .get('http://httpbin.org/get?foo=bar&bar=baz')
+  .inspect(function(err, req, res, body, headers) {
+	console.log('Got args:' + body.args);
+})
+.toss()
+```
+
+### inspectRequest(message)
+Inspects the entire request object sent from IcedFrisby.
+* Types: `message`: `string` An optional message to print before the inspection
+* Defaults: `none`
 
 ```javascript
 frisby.create('Just a quick inspection of the JSON HTTP response')
   .get('http://httpbin.org/get?foo=bar&bar=baz')
-    .inspectJSON()
-.toss()
+  .inspectRequest()
+  .toss()
+```
+
+### inspectResponse(message)
+Inspects the entire response.
+* Types: `message`: `string` An optional message to print before the inspection
+* Defaults: `none`
+
+```javascript
+frisby.create('Just a quick inspection of the JSON HTTP response')
+  .get('http://httpbin.org/get?foo=bar&bar=baz')
+  .inspectResponse()
+  .toss()
+```
+
+### inspectHeaders(message)
+Inspects the response headers.
+* Types: `message`: `string` An optional message to print before the inspection
+* Defaults: `none`
+
+```javascript
+frisby.create('Just a quick inspection of the JSON HTTP response')
+  .get('http://httpbin.org/get?foo=bar&bar=baz')
+  .inspectHeaders()
+  .toss()
+```
+
+### inspectJSON(message)
+Dumps parsed JSON body to the console.
+* Types: `message`: `string` An optional message to print before the inspection
+* Defaults: `none`
+
+```javascript
+frisby.create('Just a quick inspection of the JSON HTTP response')
+  .get('http://httpbin.org/get?foo=bar&bar=baz')
+  .inspectJSON()
+  .toss()
 ```
 
 ```javascript
@@ -378,15 +436,17 @@ frisby.create('Just a quick inspection of the JSON HTTP response')
   origin: '127.0.0.1' }
 ```
 
-### inspectBody()
-Dumps the raw response body to the console without any parsing or added markup.
+### inspectBody(message)
+Dumps the raw response body to the console without any parsing.
+* Types: `message`: `string` An optional message to print before the inspection
+* Defaults: `none`
 
 ```javascript
 // Test
 frisby.create('Very useful for HTML, text, or raw output')
   .get('http://asciime.heroku.com/generate_ascii?s=Frisby.js')
-    .inspectBody()
-.toss()
+  .inspectBody()
+  .toss()
 ```
 
 Console output:
@@ -399,6 +459,18 @@ Console output:
  |_|  |_|  |_|___/_.__/ \__, (_) |___/
                          __/ |_/ |
                         |___/|__/
+```
+
+### inspectStatus(message)
+Inspects the response status.
+* Types: `message`: `string` An optional message to print before the inspection
+* Defaults: `none`
+
+```javascript
+frisby.create('Just a quick inspection of the JSON HTTP response')
+  .get('http://httpbin.org/get?foo=bar&bar=baz')
+  .inspectStatus()
+  .toss()
 ```
 
 ### Send Raw JSON or POST Body

--- a/README.md
+++ b/README.md
@@ -114,11 +114,9 @@ Contributions are awesome! If you have an idea or code that you want to contribu
 
 ### Roadmap
 1. Make output errors more useful. It can be hard to track down which assertion is causing what error.
-1. More test coverage!
-1. README API guide
 1. Add a "stack trace" for paths to help discern why a path traversal failed
-1. Support [chained tests](https://github.com/vlucas/frisby/issues/223)
-1. ES6 support
+1. Support [chained tests/promises](https://github.com/vlucas/frisby/issues/223). Related: [#127](https://github.com/vlucas/frisby/issues/127), [#154](https://github.com/vlucas/frisby/issues/154), [#200](https://github.com/vlucas/frisby/issues/200)
+1. custom assertion plugin support
 
 ## License
 Licensed under the [MIT](http://opensource.org/licenses/MIT)/[BSD](http://opensource.org/licenses/BSD-3-Clause) license.

--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -11,6 +11,7 @@
 // IcedFrisby is distributed under the BSD license
 // http://www.opensource.org/licenses/bsd-license.php
 
+var nodeUtil = require('util');
 var pm = require('./pathMatch');
 var qs = require('qs');
 var util = require('util');
@@ -96,8 +97,9 @@ function Frisby(msg) {
     describe: msg,
     itInfo: null,
     it: null,
-    isNot: false, // For Jasmine test negation
-    expects: [],
+    isNot: false, // test negation
+    inspections: [], // array of inspections to perform before the expectations
+    expects: [], // array expectations to perform
     after: [],
     retry: _gs.retry || 0,
     retry_backoff: _gs.retry_backoff || 1000,
@@ -422,20 +424,20 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
 
 // Max Response time expect helper
 Frisby.prototype.expectMaxResponseTime = function(milliseconds) {
-  var self = this;
-  this.current.expects.push(function() {
-    expect(self.current.response.time).to.be.lessThan(milliseconds);
-});
-  return this;
+    var self = this;
+    this.current.expects.push(function() {
+        expect(self.current.response.time).to.be.lessThan(milliseconds);
+    });
+    return this;
 };
 
 // HTTP status expect helper
 Frisby.prototype.expectStatus = function(statusCode) {
-  var self = this;
-  this.current.expects.push(function() {
-    expect(self.current.response.status).to.equal(statusCode);
-});
-  return this;
+    var self = this;
+    this.current.expects.push(function() {
+        expect(self.current.response.status).to.equal(statusCode);
+    });
+    return this;
 };
 
 // HTTP header expect helper
@@ -584,70 +586,96 @@ Frisby.prototype.expectJSONLength = function(expectedLength) {
 };
 
 
-// Debugging helper to inspect HTTP request sent by Frisby
-Frisby.prototype.inspectRequest = function(message) {
+// Callback function to perform an inspection of the request or response data
+// This is run after request is made but before test is completed
+Frisby.prototype.inspect = function(cb) {
+  // do nothing if no callback was provided
+  if (!cb) {
+    return this;
+  }
+
   var self = this;
-  this.after(function(err, res, body) {
-    if (message) {
-        console.log(message);
-    }
-    console.log(self.currentRequestFinished.req);
+  this.current.inspections.push(function() {
+    cb.call(this, self.current.response.error, self.currentRequestFinished.req, self.currentRequestFinished.res, self.current.response.body, self.current.response.headers);
   });
+  return this;
+};
+
+// Debugging helper to inspect HTTP request sent by Frisby
+// @param message String message to print before the inspection
+Frisby.prototype.inspectRequest = function(message) {
+  this.inspect(
+    function(err, req, res, body) {
+      if (message) {
+        console.log(message);
+      }
+      console.log(req);
+    });
   return this;
 };
 
 // Debugging helper to inspect HTTP response received from server
+// @param message String message to print before the inspection
 Frisby.prototype.inspectResponse = function(message) {
-  this.after(function(err, res, body) {
-    if (message) {
+  this.inspect(
+    function(err, req, res, body) {
+      if (message) {
         console.log(message);
-    }
-    console.log(res);
-  });
+      }
+      console.log(res);
+    });
   return this;
 };
 
 // Debugging helper to inspect the HTTP headers that are returned from the server
-Frisby.prototype.inspectHeaders = function(message){
-  this.after(function(err, res, body) {
-    if (message) {
+// @param message String message to print before the inspection
+Frisby.prototype.inspectHeaders = function(message) {
+  this.inspect(
+    function(err, req, res, body) {
+      if (message) {
         console.log(message);
-    }
-    console.log(res.headers);
-  });
+      }
+      console.log(res.headers);
+    });
   return this;
 };
 
 // Debugging helper to inspect HTTP response body content received from server
+// @param message String message to print before the inspection
 Frisby.prototype.inspectBody = function(message) {
-  this.after(function(err, res, body) {
-    if (message) {
+  this.inspect(
+    function(err, req, res, body) {
+      if (message) {
         console.log(message);
-    }
-    console.log(body);
-  });
+      }
+      console.log(body);
+    });
   return this;
 };
 
 // Debugging helper to inspect JSON response body content received from server
+// @param message String message to print before the inspection
 Frisby.prototype.inspectJSON = function(message) {
-  this.after(function(err, res, body) {
-    if (message) {
+  this.inspect(
+    function(err, req, res, body) {
+      if (message) {
         console.log(message);
-    }
-    console.log(util.inspect(_jsonParse(body), false, 10, true));
-  });
+      }
+      console.log(util.inspect(_jsonParse(body), false, 10, true));
+    });
   return this;
 };
 
 // Debugging helper to inspect HTTP response code received from server
+// @param message String message to print before the inspection
 Frisby.prototype.inspectStatus = function(message) {
-  this.after(function(err, res, body) {
-    if (message) {
+  this.inspect(
+    function(err, req, res, body) {
+      if (message) {
         console.log(message);
-    }
-    console.log(res.statusCode);
-  });
+      }
+      console.log(res.statusCode);
+    });
   return this;
 };
 
@@ -786,9 +814,19 @@ Frisby.prototype.toss = function(retry) {
         self.current.it(function(data) {
           if (!timeoutFinished) {
             clearTimeout(timeoutId);
+            performInspections();
             assert();
           }
         });
+      }
+
+
+      // Perform inspections
+      function performInspections() {
+        for(i=0; i < self.current.inspections.length; i++) {
+          var fn = self.current.inspections[i];
+          fn.call(self);
+        }
       }
 
 

--- a/spec/frisby_inspect.spec.js
+++ b/spec/frisby_inspect.spec.js
@@ -1,0 +1,188 @@
+var frisby = require('../lib/icedfrisby');
+var expect = require('chai').expect;
+var nock = require('nock');
+
+describe('IcedFrisby inspect methods', function() {
+
+    it('should perform no action if null is provided to the inspect() callback', function() {
+        var inspectNock = nock('http://inspect-null.httpbin.org')
+            .get('/get')
+            .once()
+            .reply(200, {
+                "args": {},
+                "headers": {
+                    "Host": "httpbin.org",
+                },
+                "origin": "127.0.0.1",
+                "url": "http://inspect.httpbin.org/get"
+            });
+
+        frisby.create(this.test.title)
+            .get('http://inspect-null.httpbin.org/get', {json: true})
+            .inspect(null)
+            .after(function() {
+                // check that the mock was consumed
+                inspectNock.done();
+            })
+            .toss();
+    });
+
+    it('should allow a call to inspect the request and response', function() {
+        var inspectNock = nock('http://inspect.httpbin.org')
+            .get('/get')
+            .reply(200, {
+                "args": {},
+                "headers": {
+                    "Host": "httpbin.org",
+                },
+                "origin": "127.0.0.1",
+                "url": "http://inspect.httpbin.org/get"
+            });
+
+        frisby.create(this.test.title)
+            .get('http://inspect.httpbin.org/get', {json: true})
+            .inspect(function(err, req, res, body, headers) {
+                expect(err).to.equal(null);
+                expect(req).to.be.an('object');
+                expect(res).to.be.an('object');
+                expect(body).to.be.an('object');
+                expect(headers).to.be.an('object');
+
+                // check that the mock was consumed
+                inspectNock.done();
+            })
+            .toss();
+    });
+
+    it('- inspectRequest should work', function() {
+        var inspectNock = nock('http://inspectRequest.httpbin.org')
+            .get('/get')
+            .reply(200, {
+                "args": {},
+                "headers": {
+                    "Host": "httpbin.org",
+                },
+                "origin": "127.0.0.1",
+                "url": "http://inspect.httpbin.org/get"
+            });
+
+        frisby.create(this.test.title)
+            .get('http://inspectRequest.httpbin.org/get', {json: true})
+            .inspectRequest()
+            .after(function() {
+                // check that the mock was consumed
+                inspectNock.done();
+            })
+            .toss();
+    });
+
+    it('- inspectResponse should work', function() {
+        var inspectNock = nock('http://inspectResponse.httpbin.org')
+            .get('/get')
+            .reply(200, {
+                "args": {},
+                "headers": {
+                    "Host": "httpbin.org",
+                },
+                "origin": "127.0.0.1",
+                "url": "http://inspect.httpbin.org/get"
+            });
+
+        frisby.create(this.test.title)
+            .get('http://inspectResponse.httpbin.org/get', {json: true})
+            .inspectResponse()
+            .after(function() {
+                // check that the mock was consumed
+                inspectNock.done();
+            })
+            .toss();
+    });
+
+    it('- inspectHeaders should work', function() {
+        var inspectNock = nock('http://inspectHeaders.httpbin.org')
+            .get('/get')
+            .reply(200, {
+                "args": {},
+                "headers": {
+                    "Host": "httpbin.org",
+                },
+                "origin": "127.0.0.1",
+                "url": "http://inspect.httpbin.org/get"
+            });
+
+        frisby.create(this.test.title)
+            .get('http://inspectHeaders.httpbin.org/get', {json: true})
+            .inspectHeaders()
+            .after(function() {
+                // check that the mock was consumed
+                inspectNock.done();
+            })
+            .toss();
+    });
+
+    it('- inspectBody should work', function() {
+        var inspectNock = nock('http://inspectBody.httpbin.org')
+            .get('/get')
+            .reply(200, {
+                "args": {},
+                "headers": {
+                    "Host": "httpbin.org",
+                },
+                "origin": "127.0.0.1",
+                "url": "http://inspect.httpbin.org/get"
+            });
+
+        frisby.create(this.test.title)
+            .get('http://inspectBody.httpbin.org/get', {json: true})
+            .inspectBody()
+            .after(function() {
+                // check that the mock was consumed
+                inspectNock.done();
+            })
+            .toss();
+    });
+
+    it('- inspectJSON should work', function() {
+        var inspectNock = nock('http://inspectJSON.httpbin.org')
+            .get('/get')
+            .reply(200, {
+                "args": {},
+                "headers": {
+                    "Host": "httpbin.org",
+                },
+                "origin": "127.0.0.1",
+                "url": "http://inspect.httpbin.org/get"
+            });
+
+        frisby.create(this.test.title)
+            .get('http://inspectJSON.httpbin.org/get', {json: true})
+            .inspectJSON()
+            .after(function() {
+                // check that the mock was consumed
+                inspectNock.done();
+            })
+            .toss();
+    });
+
+    it('- inspectStatus should work', function() {
+        var inspectNock = nock('http://inspectStatus.httpbin.org')
+            .get('/get')
+            .reply(200, {
+                "args": {},
+                "headers": {
+                    "Host": "httpbin.org",
+                },
+                "origin": "127.0.0.1",
+                "url": "http://inspect.httpbin.org/get"
+            });
+
+        frisby.create(this.test.title)
+            .get('http://inspectStatus.httpbin.org/get', {json: true})
+            .inspectStatus()
+            .after(function() {
+                // check that the mock was consumed
+                inspectNock.done();
+            })
+            .toss();
+    });
+});

--- a/spec/frisby_inspect.spec.js
+++ b/spec/frisby_inspect.spec.js
@@ -68,7 +68,7 @@ describe('IcedFrisby inspect methods', function() {
 
         frisby.create(this.test.title)
             .get('http://inspectRequest.httpbin.org/get', {json: true})
-            .inspectRequest()
+            .inspectRequest('inspectRequest')
             .after(function() {
                 // check that the mock was consumed
                 inspectNock.done();
@@ -90,7 +90,7 @@ describe('IcedFrisby inspect methods', function() {
 
         frisby.create(this.test.title)
             .get('http://inspectResponse.httpbin.org/get', {json: true})
-            .inspectResponse()
+            .inspectResponse('inspectResponse')
             .after(function() {
                 // check that the mock was consumed
                 inspectNock.done();
@@ -112,7 +112,7 @@ describe('IcedFrisby inspect methods', function() {
 
         frisby.create(this.test.title)
             .get('http://inspectHeaders.httpbin.org/get', {json: true})
-            .inspectHeaders()
+            .inspectHeaders('inspectHeaders')
             .after(function() {
                 // check that the mock was consumed
                 inspectNock.done();
@@ -134,7 +134,7 @@ describe('IcedFrisby inspect methods', function() {
 
         frisby.create(this.test.title)
             .get('http://inspectBody.httpbin.org/get', {json: true})
-            .inspectBody()
+            .inspectBody('inspectBody')
             .after(function() {
                 // check that the mock was consumed
                 inspectNock.done();
@@ -156,7 +156,7 @@ describe('IcedFrisby inspect methods', function() {
 
         frisby.create(this.test.title)
             .get('http://inspectJSON.httpbin.org/get', {json: true})
-            .inspectJSON()
+            .inspectJSON('inspectJSON')
             .after(function() {
                 // check that the mock was consumed
                 inspectNock.done();
@@ -178,7 +178,7 @@ describe('IcedFrisby inspect methods', function() {
 
         frisby.create(this.test.title)
             .get('http://inspectStatus.httpbin.org/get', {json: true})
-            .inspectStatus()
+            .inspectStatus('inspectStatus')
             .after(function() {
                 // check that the mock was consumed
                 inspectNock.done();


### PR DESCRIPTION
This also includes tests and API docs.