### PR TITLE
refactor(lib): add check for content-type header

### DIFF
--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -352,7 +352,14 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
   if (data) {
     // if JSON data
     if(outgoing.json) {
-      outgoing.headers['content-type'] = 'application/json';
+      
+      var isContentTypeHeaderMissing = outgoing.headers['content-type'] &&
+                                       outgoing.headers['content-type'].indexOf('application/json') === -1;
+
+      if (isContentTypeHeaderMissing) {
+        outgoing.headers['content-type'] = 'application/json';
+      }
+
       outgoing.body = data;
     } else if(!outgoing.body) {
       if(data instanceof Buffer) {


### PR DESCRIPTION
This fixes the unchecked overwriting of an already 
defined `Content-Type` header field set via `#addHeader()`
when sending a `PUT` request with `{ json: true }`

Sample: 
```javascript
frisby
  .create()
  .setHeader('content-type', 'application/json;charset=utf-8')
  .put('http://endpoint/', {}, { json:true }
  .inspectRequest()
  .toss()
```

Output from ```#inspectRequest()```
Before: 

```json
'content-type': 'application/json'
```

After:

```json
'content-type': 'application/json;charset=UTF-8'
```