### PR TITLE
When useApp is used in the global setup, don't spin up the app for every test

### DIFF
--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -69,6 +69,11 @@ var globalSetup = function(opts) {
 
     // merge the passed in options with the defaults
     _frisbyGlobalSetup = _.merge(_.cloneDeep(getGlobalDefaults()), opts);
+
+    // start app once per global setup
+    if(_frisbyGlobalSetup.useApp) {
+      _frisbyGlobalSetup.request.baseUri = _useAppImpl(_frisbyGlobalSetup.useApp);
+    }
   }
 
   return _frisbyGlobalSetup;
@@ -119,10 +124,6 @@ function Frisby(msg) {
     }
   };
 
-  if (_gs.useApp) {
-    this.useApp(_gs.useApp);
-  }
-
   this.currentRequestFinished = false;
 
   // Default timeout
@@ -134,16 +135,22 @@ function Frisby(msg) {
   return this;
 }
 
-
-//
 // Setup the request to use a passed in Node http.Server app
+//
+// @param app Node.js app. E.g. Express, Koa
+// @param basePath base path to append to the server address
+Frisby.prototype.useApp = function(app, basePath) {
+  this.current.request.baseUri = _useAppImpl(app, basePath);
+  return this;
+};
+
 // Builds the baseUri from the application, replacing
 // any baseUri setup in globalSetup
 //
 // @param app Node.js app. E.g. Express, Koa
 // @param basePath base path to append to the server address
-//
-Frisby.prototype.useApp = function(app, basePath) {
+// @return built base uri
+function _useAppImpl (app, basePath) {
   // sanity check app
   if (!app) {
     throw new Error('No app provided');
@@ -155,10 +162,9 @@ Frisby.prototype.useApp = function(app, basePath) {
   var address = app.listen().address();
   var port = address.port;
   var protocol = app instanceof https.Server ? 'https' : 'http';
-  this.current.request.baseUri = protocol + '://127.0.0.1:' + port + basePath;
 
-  return this;
-};
+  return protocol + '://127.0.0.1:' + port + basePath;
+}
 
 
 //


### PR DESCRIPTION
When useApp is used in the global setup, don't spin up the app for every test